### PR TITLE
Re-creating a left behind PR

### DIFF
--- a/modules/ROOT/pages/xml-sdk.adoc
+++ b/modules/ROOT/pages/xml-sdk.adoc
@@ -517,9 +517,9 @@ hello-smart-connector
 +
 (2) `hello-smart-connector/smart-connector-it/src/test/munit/assertion-munit-test.xml`: An assertion operation that calls the XML SDK operation.
 +
-. Run `mvn clean install` in the `/hello-smart-connector` to create the plugin for the `Hello XML SDK` module. This will install a parent project as well as child projects.
+. Run `mvn clean install` in the `/hello-smart-connector` to create the plugin for the `Hello XML SDK` module.
 +
-This command also runs the suite through MUnit for the operation defined in the module.
+This command installs a parent project as well as its child projects. It also runs the suite through MUnit for the operation defined in the module.
 +
 [source,text,linenums]
 ----
@@ -543,7 +543,7 @@ This command also runs the suite through MUnit for the operation defined in the 
 ➜  hello-smart-connector
 ----
 +
-(3) When you want to add this connector to your project from your local Maven repository for testing, you need only add the following dependency to use this connector from your Studio palette.
+(3) When you want to add this connector to a project from your local Maven repository for testing, add the following dependency:
 ----
 <dependency>
        <groupId>org.mule.smart.connector</groupId>
@@ -552,6 +552,9 @@ This command also runs the suite through MUnit for the operation defined in the 
        <classifier>mule-plugin</classifier>
 </dependency>
 ----
++
+You can now use this connector from your Studio palette.
++
 == Consuming a Mule Plugin from an XML SDK Module
 
 To consume a Mule plugin from within an XML SDK module:
@@ -1430,7 +1433,7 @@ GitHub Location: https://github.com/mulesoft-labs/smart-connectors-integration-t
  </module>
 ----
 
-=== Using Validation Module
+=== Using the Validation Module
 
 This example uses the Validation module, specifically `validation:is-email`.
 
@@ -1461,7 +1464,7 @@ GitHub Location: https://github.com/mulesoft-labs/smart-connectors-integration-t
  </module>
 ----
 
-== XML SDK limitations
+== XML SDK Limitations
 
 The SDK currently has the following limitations:
 

--- a/modules/ROOT/pages/xml-sdk.adoc
+++ b/modules/ROOT/pages/xml-sdk.adoc
@@ -517,7 +517,7 @@ hello-smart-connector
 +
 (2) `hello-smart-connector/smart-connector-it/src/test/munit/assertion-munit-test.xml`: An assertion operation that calls the XML SDK operation.
 +
-. Run `mvn clean install` in the `/hello-smart-connector` to create the plugin for the `Hello XML SDK` module.
+. Run `mvn clean install` in the `/hello-smart-connector` to create the plugin for the `Hello XML SDK` module. This will install a parent project as well as child projects.
 +
 This command also runs the suite through MUnit for the operation defined in the module.
 +
@@ -542,8 +542,17 @@ This command also runs the suite through MUnit for the operation defined in the 
 [INFO] ------------------------------------------------------------------------
 ➜  hello-smart-connector
 ----
-
-== Consuming Mule Plugin from an XML SDK Module
++
+(3) When you want to add this connector to your project from your local Maven repository for testing, you need only add the following dependency to use this connector from your Studio palette.
+----
+<dependency>
+       <groupId>org.mule.smart.connector</groupId>
+       <artifactId>hello-smart-connector-smart-connector</artifactId>
+       <version>1.0.0-SNAPSHOT</version>
+       <classifier>mule-plugin</classifier>
+</dependency>
+----
+== Consuming a Mule Plugin from an XML SDK Module
 
 To consume a Mule plugin from within an XML SDK module:
 


### PR DESCRIPTION
This PR was left behind in the main mulesoft-docs repo (now read-only).

Review the original
https://github.com/mulesoft/mulesoft-docs/pull/3245/commits/45b8c36da82fd1657105f24f5b7109df22102bb8

and compare to these updates.