### PR TITLE
Edits on dynamic-port global element note.

### DIFF
--- a/modules/ROOT/pages/munit-extensions-maven-plugin-configuration.adoc
+++ b/modules/ROOT/pages/munit-extensions-maven-plugin-configuration.adoc
@@ -133,9 +133,10 @@ From the command line, the property is `discoverRuntimes.skip`.
 
 == Dynamic Ports
 
-WARNING: Since MUnit 2.2, the concept of the global element `dynamic-port` was introduced that allows you to define
-dynamic ports at the MUnit suite level. Using this element instead of the following plugin configuration will allow
-the dynamic port to be set both from Maven and Studio. To learn more follow this xref:2.2@munit::dynamic-ports.adoc[link]
+[IMPORTANT]
+MUnit 2.2 and later introduce the `dynamic-port` global element, that allows you to define dynamic ports at the MUnit suite level. +
+Using this element instead of the following plugin configuration allows you to set the dynamic port both from Maven and Studio. +
+See xref:2.2@munit::dynamic-ports.adoc[Dynamic Ports] in MUnit to learn how to configure this element.
 
 When testing a Mule application in a continuous integration (CI) environment, you might encounter the following scenario:
 

--- a/modules/ROOT/pages/munit-extensions-maven-plugin-configuration.adoc
+++ b/modules/ROOT/pages/munit-extensions-maven-plugin-configuration.adoc
@@ -135,7 +135,7 @@ From the command line, the property is `discoverRuntimes.skip`.
 
 [IMPORTANT]
 MUnit 2.2 and later introduce the `dynamic-port` global element, that allows you to define dynamic ports at the MUnit suite level. +
-Using this element instead of the following plugin configuration allows you to set the dynamic port both from Maven and Studio. +
+Using this element instead of the plugin configuration described below allows you to set the dynamic port both from Maven and Studio. +
 See xref:2.2@munit::dynamic-ports.adoc[Dynamic Ports] in MUnit to learn how to configure this element.
 
 When testing a Mule application in a continuous integration (CI) environment, you might encounter the following scenario:


### PR DESCRIPTION
Removing usage of passive voice and rewording links usage to MUnit 2.2 documentation.