### PR TITLE
remove junk from topic

### DIFF
--- a/modules/ROOT/pages/testing.adoc
+++ b/modules/ROOT/pages/testing.adoc
@@ -10,9 +10,3 @@ Here are a series of articles that explain in detail how to test your module. It
 
 * <<testing-writing-your-first-test-case#, Writing your first test case>>
 * xref:testing-writing-your-first-test-case.adoc#testing-flowrunner[FlowRunner]
-* Operations, Scopes and Routers
-* Sources
-* DataSense Resolution
-* ValueProviders Resolution
-* Handling ClassLoading Issues
-* Best Practices


### PR DESCRIPTION
The bullet items with no links don't match any content and that content is not currently on a backlog.
Confirmed by SDK team.