### PR TITLE
documenting XML SDK visibility attribute since 4.2+

### DIFF
--- a/modules/ROOT/pages/xml-sdk.adoc
+++ b/modules/ROOT/pages/xml-sdk.adoc
@@ -151,6 +151,13 @@ See xref:content-parameters.adoc[more info on roles].
 | NA
 | Defines the group (or tab) to which the `<parameter>` must belong in the UI.
 
+| `visibility`
+| optional
+| `PUBLIC`
+| *Available since version 1.2* 
+
+Marks an operation's visibility to either `PUBLIC` (anyone can see it, and use it) to `PRIVATE` which will make it accessible *only* for the current module (and it won't also be seen from the outside).
+
 | `doc:description`
 | optional
 | NA

--- a/modules/ROOT/pages/xml-sdk.adoc
+++ b/modules/ROOT/pages/xml-sdk.adoc
@@ -156,7 +156,7 @@ See xref:content-parameters.adoc[more info on roles].
 | `PUBLIC`
 | *Available since version 1.2* 
 
-Marks an operation's visibility to either `PUBLIC` (anyone can see it, and use it) to `PRIVATE` which will make it accessible *only* for the current module (and it won't also be seen from the outside).
+Marks an operation's visibility to either `PUBLIC` (anyone can see and use it) to `PRIVATE` (accessible only for the current module and cannot be seen externally).
 
 | `doc:description`
 | optional


### PR DESCRIPTION
since https://www.mulesoft.org/jira/browse/MULE-14385, it's possible to have private operations in XML SDK.
Documenting it.