### PR TITLE
Add comment clarifying when to use value providers instead of datasense (#64)

### DIFF
--- a/modules/ROOT/pages/metadata.adoc
+++ b/modules/ROOT/pages/metadata.adoc
@@ -17,6 +17,8 @@ Integration developers often spend a lot of time trying to determine the input a
 
 DataSense uses the metadata provided by these components to resolve all this information automatically and present it to your end user in design time, which drastically increases the speed of development.
 
+Note that unlike xref:value-providers.adoc[Value Providers], which are meant to narrow down the possible values that a parameter of a known type can take, this feature is to discover dynamic types whose universe of possible values is not to be discovered by this feature.
+
 The term "types" refers to the `MetadataType` of an element. A `MetadataType` represents the kind and structure of a given element, like `StringType` or `NumberType` for elements that are basic string or numbers, `ArrayType` for collections, `ObjectType` for complex structures with nested elements (like a POJO or a JSON object), and `AnyType` for elements whose type is actually unknown and can be any of the other available types.
 
 See xref:4.1@mule-runtime::dataweave-types.adoc[DataWeave Types].

--- a/modules/ROOT/pages/value-providers.adoc
+++ b/modules/ROOT/pages/value-providers.adoc
@@ -11,6 +11,8 @@ You can provide this functionality for known values by using a <<java_enum, Java
 
 To include values that are not known, such as custom values, you should use <<value_providers, Value Providers>>, instead.
 
+Note that unlike xref:metadata.adoc[Metadata], which is meant to discover the dynamic types of a parameter, this feature is designed to provide the possible values of a parameter.
+
 [[java_enum]]
 == Java Enum
 


### PR DESCRIPTION
* Add comment clarifying when to use value providers instead of datasense

* Minor

* Minor

Co-authored-by: Kevin Troller <kevinmeinrad.troller@mulesoft.com>