### PR TITLE
Spelling mistake corrected - "taht" -> "that" in the https://docs.mulesoft.com/mule-sdk/1.1/configs

### DIFF
--- a/modules/ROOT/pages/configs.adoc
+++ b/modules/ROOT/pages/configs.adoc
@@ -109,7 +109,7 @@ parameters, it also turns out that:
 * To send a request, you need an `<http:request />` element that acts as an operation.
 
 Because an application can contain many listener elements, the elements will only work when
-paired with an `<http:listener-config />` taht contains general settings about how the
+paired with an `<http:listener-config />` that contains general settings about how the
 connection is to be established and other behavioral parameters. The same happens with the requester
 operation, which is paired with an `<http:requester-config />` element.
 


### PR DESCRIPTION
I have included the screenshot for reference,
Kindly Open the link for reference - https://ibb.co/cw75wRS

There is a spelling mistake.