### PR TITLE
DOCSINFRA-225 - Make v1.1 the default and only non-versioned production branch

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,5 +1,5 @@
 name: mule-sdk
 title: Mule SDK
-version: '1.1'
+version: 'master'
 nav:
 - modules/ROOT/nav.adoc

--- a/modules/ROOT/pages/HTTP-based-connectors.adoc
+++ b/modules/ROOT/pages/HTTP-based-connectors.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::HTTP-based-connectors.adoc, 1.2@mule-sdk::HTTP-based-connectors.adoc
 
 There is a special set of considerations for connectors that access a remote system by either issuing HTTP requests or exposing HTTP endpoints.
 

--- a/modules/ROOT/pages/about-connector-certification-program-guidelines.adoc
+++ b/modules/ROOT/pages/about-connector-certification-program-guidelines.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::about-connector-certification-program-guidelines.adoc, 1.2@mule-sdk::about-connector-certification-program-guidelines.adoc
 :keywords: connector, certification, sdk, program guidelines
 
 This document pertains to connector certification for Mule 4. For Mule 3 certification, see xref:3.9@connector-devkit::connector-certification-program-guidelines.adoc[DevKit documentation].

--- a/modules/ROOT/pages/advanced-parameter-handling.adoc
+++ b/modules/ROOT/pages/advanced-parameter-handling.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::advanced-parameter-handling.adoc, 1.0@mule-sdk::advanced-parameter-handling.adoc, 1.2@mule-sdk::advanced-parameter-handling.adoc
 
 Features in the SDK can improve the quality of your module by adding UI and UX tuning, enabling extension points so your module can interact with elements of other modules, and providing implementation enhancements to avoid boilerplate code.
 

--- a/modules/ROOT/pages/authentication-handler.adoc
+++ b/modules/ROOT/pages/authentication-handler.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::authentication-handler.adoc, 1.0@mule-sdk::authentication-handler.adoc, 1.2@mule-sdk::authentication-handler.adoc
 
 This handler allows you to configure the current context's authentication, which is used for encryption and inbound authentication, based on a given request.
 

--- a/modules/ROOT/pages/authorization-code.adoc
+++ b/modules/ROOT/pages/authorization-code.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mules-sdk::authorization-code.adoc
 :keywords: mule, sdk, grant, oauth
 
 Authorization Code is a grant type that allows an application to act on behalf of a user without the need for that user to share their actual credentials. This grant type allows an application to impersonate a user.

--- a/modules/ROOT/pages/best-practices.adoc
+++ b/modules/ROOT/pages/best-practices.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::best-practices.adoc, 1.0@mule-sdk::best-practices.adoc, 1.2@mule-sdk::best-practices.adoc
 
 The purpose of this documentation is to provide users of the Mule SDK with best practices for building modules and connectors in a way that makes the best use of Mule runtime engine (Mule) functionality and is consistent with MuleSoft’s UX and quality guidelines.
 

--- a/modules/ROOT/pages/binary-streaming.adoc
+++ b/modules/ROOT/pages/binary-streaming.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::binary-streaming.adoc, 1.0@mule-sdk::binary-streaming.adoc, 1.2@mule-sdk::binary-streaming.adoc
 :keywords: mule, sdk, streaming, binary
 
 In binary streaming use cases, the stream is a flux of bytes that are treated in a generic way regardless of what they represent. Examples include the response of an HTTP request or retrieving and writing a file in a FTP server.

--- a/modules/ROOT/pages/certification-guidelines-for-connectors.adoc
+++ b/modules/ROOT/pages/certification-guidelines-for-connectors.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::certification-guidelines-for-connectors.adoc, 1.2@mule-sdk::certification-guidelines-for-connectors.adoc
 :keywords: connector, certification, sdk, program guidelines
 
 . Set up your development environment using these sections from _Getting Started with the Mule SDK_:

--- a/modules/ROOT/pages/choosing-version.adoc
+++ b/modules/ROOT/pages/choosing-version.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::choosing-version.adoc, 1.0@mule-sdk::choosing-version.adoc, 1.2@mule-sdk::choosing-version.adoc
 :keywords: mule, sdk, create, new, project, getting, started, version
 
 //TODO: IS THIS 1.1 ONLY, NOT 1.0

--- a/modules/ROOT/pages/client-credentials.adoc
+++ b/modules/ROOT/pages/client-credentials.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::client-credentials.adoc
 :keywords: mule, sdk, grant, oauth
 
 Available since version 1.3.
@@ -262,7 +263,7 @@ The obtained access tokens are stored in an Object Store. By default, the SDK st
 == Refresh an Expired Client Credentials Access Token
 
 Most access tokens have a limited lifespan: typically about 30 to 60 minutes after being issued. This is why most providers also supply a refresh token, which eliminates the need to perform the OAuth dance again, although this is not a standard that is strictly enforced by providers.
-There is not an enforced standard that the SDK automatically detects an expired token and replaces it. Because different APIs communicate that in different ways, the `AccessTokenExpiredException` exception exists, shown below: 
+There is not an enforced standard that the SDK automatically detects an expired token and replaces it. Because different APIs communicate that in different ways, the `AccessTokenExpiredException` exception exists, shown below:
 
 [source, java, linenums]
 ----

--- a/modules/ROOT/pages/config-override.adoc
+++ b/modules/ROOT/pages/config-override.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::config-override.adoc, 1.0@mule-sdk::config-override.adoc, 1.2@mule-sdk::config-override.adoc
 :keywords: mule, sdk, config, configuration, override, parameter
 
 A parameter in your configuration that serves as a _global default_ specifies a default value or behavior for other operations and sources to use. For components in an app to override the value of that parameter, you can use `@ConfigOverride`.

--- a/modules/ROOT/pages/configs.adoc
+++ b/modules/ROOT/pages/configs.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::configs.adoc, 1.0@mule-sdk::configs.adoc, 1.2@mule-sdk::configs.adoc
 :keywords: mule, sdk, config, configuration
 
 Configurations are a set of configurable parameters that affect the overall behavior of your module.

--- a/modules/ROOT/pages/connections.adoc
+++ b/modules/ROOT/pages/connections.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::connections.adoc, 1.0@mule-sdk::connections.adoc, 1.2@mule-sdk::connections.adoc
 :keywords: mule, sdk, connection, connectivity, management, pooling, cached, provider, connection-provider
 
 Connected modules (connectors) are probably the most common type of module.

--- a/modules/ROOT/pages/content-parameters.adoc
+++ b/modules/ROOT/pages/content-parameters.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::content-parameters.adoc, 1.0@mule-sdk::content-parameters.adoc, 1.2@mule-sdk::content-parameters.adoc
 
 [[_content-parameters]]
 

--- a/modules/ROOT/pages/context-information-injection.adoc
+++ b/modules/ROOT/pages/context-information-injection.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::context-information-injection.adoc, 1.0@mule-sdk::context-information-injection.adoc, 1.2@mule-sdk::context-information-injection.adoc
 :keywords: mule, sdk, context, inject, event, location
 
 To get information about the context in which an operation or source is being processed, you can add parameters to the operation or source. The parameters do not appear in the UI, but they are injected by the SDK into the runtime.

--- a/modules/ROOT/pages/define-configurations-and-connection-providers.adoc
+++ b/modules/ROOT/pages/define-configurations-and-connection-providers.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::define-configurations-and-connection-providers.adoc, 1.2@mule-sdk::define-configurations-and-connection-providers.adoc
 
 == Distributing Parameters
 

--- a/modules/ROOT/pages/define-operations.adoc
+++ b/modules/ROOT/pages/define-operations.adoc
@@ -2,6 +2,8 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::define-operations.adoc, 1.2@mule-sdk::define-operations.adoc
+:page-aliases: 1.1@mule-sdk::define-operations.adoc, 1.2@mule-sdk::define-operations.adoc
 
 The sections that follow provide general rules that apply to all operations.
 

--- a/modules/ROOT/pages/define-operations.adoc
+++ b/modules/ROOT/pages/define-operations.adoc
@@ -4,6 +4,7 @@ include::_attributes.adoc[]
 endif::[]
 :page-aliases: 1.1@mule-sdk::define-operations.adoc, 1.2@mule-sdk::define-operations.adoc
 :page-aliases: 1.1@mule-sdk::define-operations.adoc, 1.2@mule-sdk::define-operations.adoc
+:page-aliases: 1.1@mule-sdk::define-operations.adoc, 1.2@mule-sdk::define-operations.adoc
 
 The sections that follow provide general rules that apply to all operations.
 

--- a/modules/ROOT/pages/define-parameters.adoc
+++ b/modules/ROOT/pages/define-parameters.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::define-parameters.adoc, 1.2@mule-sdk::define-parameters.adoc
 
 Defining parameters well is a key aspect of the usability of any component. Even if the components provides awesome functionality, the user is not going to have a great experience if the component is not easy and intuitive to configure.
 Handling JSON and XML Parameters

--- a/modules/ROOT/pages/define-parameters.adoc
+++ b/modules/ROOT/pages/define-parameters.adoc
@@ -1,4 +1,4 @@
-== Defining Parameters
+= Defining Parameters
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]

--- a/modules/ROOT/pages/define-sources.adoc
+++ b/modules/ROOT/pages/define-sources.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::define-sources.adoc, 1.2@mule-sdk::define-sources.adoc
 
 == Assure Restartability
 

--- a/modules/ROOT/pages/dmt.adoc
+++ b/modules/ROOT/pages/dmt.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::dmt.adoc, 1.2@mule-sdk::dmt.adoc
 :keywords: mule, sdk, devkit, migration, migrate, connector
 
 The DevKit Migration Tool (DMT) helps you migrate from a Connector built with DevKit that runs on Mule 3.x to a project that is compatible with Mule 4 SDK.

--- a/modules/ROOT/pages/error-handling.adoc
+++ b/modules/ROOT/pages/error-handling.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::error-handling.adoc, 1.2@mule-sdk::error-handling.adoc
 
 == Defining Error Types
 

--- a/modules/ROOT/pages/errors.adoc
+++ b/modules/ROOT/pages/errors.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::errors.adoc, 1.0@mule-sdk::errors.adoc, 1.2@mule-sdk::errors.adoc
 :keywords: error, sdk, error handling, operations, try, catch, on error, propagate
 
 In Mule, errors are a way of communicating that something went wrong and providing meaningful information so that a user can take corrective action depending on the kind of error that was thrown.

--- a/modules/ROOT/pages/exclusive-optionals.adoc
+++ b/modules/ROOT/pages/exclusive-optionals.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::exclusive-optionals.adoc, 1.0@mule-sdk::exclusive-optionals.adoc, 1.2@mule-sdk::exclusive-optionals.adoc
 :keywords: mule, sdk, annotation, exclusive, optional
 
 When you are developing a module that provides several ways of configuring the same thing, but only one of them should be used, you might need to set the following rule:

--- a/modules/ROOT/pages/external-libs.adoc
+++ b/modules/ROOT/pages/external-libs.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::external-libs.adoc, 1.0@mule-sdk::external-libs.adoc, 1.2@mule-sdk::external-libs.adoc
 :keywords: mule, SDK, library, dependency, external, jar, maven
 
 Connectors and Modules sometimes depend on external libraries that cannot

--- a/modules/ROOT/pages/functions.adoc
+++ b/modules/ROOT/pages/functions.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::functions.adoc, 1.0@mule-sdk::functions.adoc, 1.2@mule-sdk::functions.adoc
 :keywords: mule, sdk, functions, function
 
 DataWeave is the main expression language in Mule 4, and the Mule SDK is also aligned with that view. This allows you to contribute functions to DataWeave from your module's code in a similar fashion that you code a Mule <<operations#, Operation>>. Using custom functions allows you to reuse code in a new way, providing extra functionality in a single Module with very little overhead regarding how they are

--- a/modules/ROOT/pages/general-coding-rules.adoc
+++ b/modules/ROOT/pages/general-coding-rules.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::general-coding-rules.adoc, 1.2@mule-sdk::general-coding-rules.adoc
 
 This set of general rules applies to any component of a module or connector. These apply on all operations, sources, configs, connection providers, and functions).
 

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::getting-started.adoc, 1.0@mule-sdk::getting-started.adoc, 1.2@mule-sdk::getting-started.adoc
 :keywords: mule, sdk, create, new, project, getting, started
 
 Create your first Mule SDK project in just a few steps:

--- a/modules/ROOT/pages/implicit-configurations.adoc
+++ b/modules/ROOT/pages/implicit-configurations.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::implicit-configurations.adoc
 
 Some configurations can be classified as implicit. A configuration can be used implicitly when none of its parameters are required. For example, suppose a `myConfig` configuration object which has a required parameter `param1`:
 

--- a/modules/ROOT/pages/imported-types.adoc
+++ b/modules/ROOT/pages/imported-types.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::imported-types.adoc, 1.0@mule-sdk::imported-types.adoc, 1.2@mule-sdk::imported-types.adoc
 :keywords: parameter, parameters, mule, sdk, dsl, xml, import, type
 
 Every module can declare a set of types that are part of the module's API. This set of types can then be imported by other modules, while keeping the original module's namespace definition.

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::index.adoc, 1.0@mule-sdk::index.adoc, 1.2@mule-sdk::index.adoc
 :keywords: mule, sdk
 
 Use the Mule SDK for Java or XML to extend the Mule 4 Runtime by creating new modules that you can install in Mule apps. Examples of modules include connectors, such as HTTP, or modules with custom functionality, such as the Validations Module.

--- a/modules/ROOT/pages/isolation.adoc
+++ b/modules/ROOT/pages/isolation.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::isolation.adoc, 1.0@mule-sdk::isolation.adoc, 1.2@mule-sdk::isolation.adoc
 :keywords: mule, sdk, classloading, isolation
 
 The Mule 4 classloading schema isolates the runtime, apps and modules from each other. Each specifies the packages (rather than the classes) to export as part of its API, making those specific packages visible.

--- a/modules/ROOT/pages/license.adoc
+++ b/modules/ROOT/pages/license.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::license.adoc, 1.0@mule-sdk::license.adoc, 1.2@mule-sdk::license.adoc
 
 Modules written with the SDK have three possible kinds of licensing, each setting different requirements on how the application can be executed.
 

--- a/modules/ROOT/pages/metadata-input.adoc
+++ b/modules/ROOT/pages/metadata-input.adoc
@@ -2,7 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
-:page-aliases: 1.1@mule-sdk::metadata-input.adoc, 1.0@mule-sdk::metadata-input.adoc, 1.2@mule-sdk::metadata-input.adoc
+:page-aliases: 1.1@mule-sdk::metadata-input.adoc, 1.0@mule-sdk::metadata-input.adoc, 1.2@mule-sdk::metadata-input.adoc, 1.0@mule-sdk::input.adoc
 :keywords: mule, sdk, metadata, datasense, input, type
 
 We refer as input Metadata to the type resolution for the Parameters of a Component.

--- a/modules/ROOT/pages/metadata-input.adoc
+++ b/modules/ROOT/pages/metadata-input.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::metadata-input.adoc, 1.0@mule-sdk::metadata-input.adoc, 1.2@mule-sdk::metadata-input.adoc
 :keywords: mule, sdk, metadata, datasense, input, type
 
 We refer as input Metadata to the type resolution for the Parameters of a Component.

--- a/modules/ROOT/pages/metadata-keys.adoc
+++ b/modules/ROOT/pages/metadata-keys.adoc
@@ -2,7 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
-:page-aliases: 1.1@mule-sdk::metadata-keys.adoc, 1.0@mule-sdk::metadata-keys.adoc, 1.2@mule-sdk::metadata-keys.adoc
+:page-aliases: 1.1@mule-sdk::metadata-keys.adoc, 1.0@mule-sdk::metadata-keys.adoc, 1.2@mule-sdk::metadata-keys.adoc, 1.0@mule-sdk::keys.adoc
 :keywords: mule, sdk, metadata, datasense, keys, type
 
 To describe a dynamic metadata structure, you need to know what type to represent. This type reference is done by defining a `@MetadataKeyId` parameter in the operation that contains the ID of the type (for example, Account) that will be passed to the metadata resolver defined for that parameter.

--- a/modules/ROOT/pages/metadata-keys.adoc
+++ b/modules/ROOT/pages/metadata-keys.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::metadata-keys.adoc, 1.0@mule-sdk::metadata-keys.adoc, 1.2@mule-sdk::metadata-keys.adoc
 :keywords: mule, sdk, metadata, datasense, keys, type
 
 To describe a dynamic metadata structure, you need to know what type to represent. This type reference is done by defining a `@MetadataKeyId` parameter in the operation that contains the ID of the type (for example, Account) that will be passed to the metadata resolver defined for that parameter.

--- a/modules/ROOT/pages/metadata-output.adoc
+++ b/modules/ROOT/pages/metadata-output.adoc
@@ -2,7 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
-:page-aliases: 1.1@mule-sdk::metadata-output.adoc, 1.0@mule-sdk::metadata-output.adoc, 1.2@mule-sdk::metadata-output.adoc
+:page-aliases: 1.1@mule-sdk::metadata-output.adoc, 1.0@mule-sdk::metadata-output.adoc, 1.2@mule-sdk::metadata-output.adoc, 1.0@mule-sdk::output.adoc
 
 [[_output_metadata]]
 //TODO: 1.1. ONLY, NO 1.0 VERSION?

--- a/modules/ROOT/pages/metadata-output.adoc
+++ b/modules/ROOT/pages/metadata-output.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::metadata-output.adoc, 1.0@mule-sdk::metadata-output.adoc, 1.2@mule-sdk::metadata-output.adoc
 
 [[_output_metadata]]
 //TODO: 1.1. ONLY, NO 1.0 VERSION?

--- a/modules/ROOT/pages/metadata.adoc
+++ b/modules/ROOT/pages/metadata.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::metadata.adoc, 1.0@mule-sdk::metadata.adoc, 1.2@mule-sdk::metadata.adoc
 :keywords: mule, sdk, metadata, datasense, input, output, keys, type
 
 DataSense is a Mule service that displays type metadata for the entities in a module.

--- a/modules/ROOT/pages/module-structure.adoc
+++ b/modules/ROOT/pages/module-structure.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::module-structure.adoc, 1.0@mule-sdk::module-structure.adoc, 1.2@mule-sdk::module-structure.adoc
 :keywords: mule, sdk, module, extension, components, structure
 
 The entry point for building a Mule module is the `@Extension` annotated class. This class is used to export all the module functionality and all the elements associated with it.

--- a/modules/ROOT/pages/mule-service-injection.adoc
+++ b/modules/ROOT/pages/mule-service-injection.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::mule-service-injection.adoc, 1.0@mule-sdk::mule-service-injection.adoc, 1.2@mule-sdk::mule-service-injection.adoc
 :keywords: mule, sdk, dependency, inject, registry, service
 
 == Using Mule Services

--- a/modules/ROOT/pages/multi-level-metadata.adoc
+++ b/modules/ROOT/pages/multi-level-metadata.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::multi-level-metadata.adoc, 1.0@mule-sdk::multi-level-metadata.adoc, 1.2@mule-sdk::multi-level-metadata.adoc
 
 Imagine the case where your end user will use an operation that invokes an action provided by a service. To know the metadata that the action requires as arguments or the metadata of what it returns, you need to differentiate the service from the action to be executed. You do this with a metadata key id. For these cases, the metadata key id does not need to be a single `String`. It can instead contain multiple parts bundled within a complex parameter that holds the information needed to resolve the metadata.
 

--- a/modules/ROOT/pages/non-blocking-operations.adoc
+++ b/modules/ROOT/pages/non-blocking-operations.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::non-blocking-operations.adoc, 1.0@mule-sdk::non-blocking-operations.adoc, 1.2@mule-sdk::non-blocking-operations.adoc
 :keywords: mule, sdk, operation, non, blocking, non-blocking
 
 The Mule 4 execution engine is based on reactive streams. That means there’s top level support for non-blocking

--- a/modules/ROOT/pages/notifications.adoc
+++ b/modules/ROOT/pages/notifications.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::notifications.adoc, 1.2@mule-sdk::notifications.adoc
 :keywords: notification, sdk, operations, sources
 
 *Available since version 1.1*

--- a/modules/ROOT/pages/null-safe.adoc
+++ b/modules/ROOT/pages/null-safe.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::null-safe.adoc, 1.0@mule-sdk::null-safe.adoc, 1.2@mule-sdk::null-safe.adoc
 :keywords: mule, sdk, annotations, null, safe
 
 In some cases, you might want to instantiate a `@Parameter` even though the end user has not provided a value, for example:

--- a/modules/ROOT/pages/oauth-configuring.adoc
+++ b/modules/ROOT/pages/oauth-configuring.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::oauth-configuring.adoc, 1.0@mule-sdk::oauth-configuring.adoc, 1.2@mule-sdk::oauth-configuring.adoc
 :keywords: mule, sdk, security, oauth
 
 //TODO: SEE resourceOwnerId

--- a/modules/ROOT/pages/oauth-dance.adoc
+++ b/modules/ROOT/pages/oauth-dance.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::oauth-dance.adoc, 1.0@mule-sdk::oauth-dance.adoc, 1.2@mule-sdk::oauth-dance.adoc
 :keywords: mule, sdk, security, oauth
 
 The final step for using the module is to trigger the OAuth dance. <<oauth-configuring#, Configuring an OAuth-Enabled Module>> includes a parameter called

--- a/modules/ROOT/pages/oauth-token-expiration.adoc
+++ b/modules/ROOT/pages/oauth-token-expiration.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::oauth-token-expiration.adoc, 1.0@mule-sdk::oauth-token-expiration.adoc, 1.2@mule-sdk::oauth-token-expiration.adoc
 :keywords: mule, sdk, security, oauth
 
 Most services providers return (or should return) access tokens with a limited lifespan. In general, access tokens usually expire about 30 to 60 minutes after being issued, although this is not a standard that strictly enforced by providers.

--- a/modules/ROOT/pages/oauth.adoc
+++ b/modules/ROOT/pages/oauth.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::oauth.adoc, 1.0@mule-sdk::oauth.adoc, 1.2@mule-sdk::oauth.adoc
 :keywords: mule, sdk, security, oauth
 
 OAuth 2.0 is the industry-standard protocol for authorization. OAuth 2.0 focuses on client developer simplicity while providing specific authorization flows for web applications, desktop applications, mobile phones, and livingroom devices. For more information about the OAuth 2.0 protocol, see https://oauth.net/2/[https://oauth.net/2/].

--- a/modules/ROOT/pages/object-streaming.adoc
+++ b/modules/ROOT/pages/object-streaming.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::object-streaming.adoc, 1.0@mule-sdk::object-streaming.adoc, 1.2@mule-sdk::object-streaming.adoc
 :keywords: mule, sdk, streaming, objects, pagination
 
 Object streaming is similar to <<binary-streaming#, binary streaming>>, except that it streams Java objects, not a raw byte stream.

--- a/modules/ROOT/pages/operations.adoc
+++ b/modules/ROOT/pages/operations.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::operations.adoc, 1.0@mule-sdk::operations.adoc, 1.2@mule-sdk::operations.adoc
 :keywords: mule, sdk, operation, processor, result, execution, void, payload,
 
 Operations are one of the most important Mule concepts because they represent the actions your module can perform inside a flow. You use them to process incoming messages through business logic that is implemented in the module.

--- a/modules/ROOT/pages/parameter-layout.adoc
+++ b/modules/ROOT/pages/parameter-layout.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::parameter-layout.adoc, 1.0@mule-sdk::parameter-layout.adoc, 1.2@mule-sdk::parameter-layout.adoc
 
 The SDK provides a set of annotations used for customizing many aspects of the UI and UX.
 

--- a/modules/ROOT/pages/parameters-dsl.adoc
+++ b/modules/ROOT/pages/parameters-dsl.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::parameters-dsl.adoc, 1.0@mule-sdk::parameters-dsl.adoc, 1.2@mule-sdk::parameters-dsl.adoc
 :keywords: parameter, parameters, mule, sdk, dsl, xml, syntax
 
 To provide the best possible experience for the user, customize or limit some aspects of a component's parameters. For example, you can hide irrelevant parameters for clarity.

--- a/modules/ROOT/pages/parameters.adoc
+++ b/modules/ROOT/pages/parameters.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::parameters.adoc, 1.0@mule-sdk::parameters.adoc, 1.2@mule-sdk::parameters.adoc
 :keywords: mule, sdk, parameter
 
 Parameters are configurable arguments that belong to a given component. <<configs#, Configurations>>, <<module-structure#components, Components>>, and <<connections#, Connection Providers>> are called _parameterizables_ because

--- a/modules/ROOT/pages/polling-sources.adoc
+++ b/modules/ROOT/pages/polling-sources.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::polling-sources.adoc, 1.2@mule-sdk::polling-sources.adoc
 
 *Available since version 1.1*
 

--- a/modules/ROOT/pages/reconnection.adoc
+++ b/modules/ROOT/pages/reconnection.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::reconnection.adoc, 1.0@mule-sdk::reconnection.adoc, 1.2@mule-sdk::reconnection.adoc
 :keywords: anypoint, studio, reconnection strategies, reconnection strategy, retry policies, retry
 
 The SDK and Mule provide out-of-the-box reconnection strategies to be applied

--- a/modules/ROOT/pages/result-object.adoc
+++ b/modules/ROOT/pages/result-object.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::result-object.adoc, 1.0@mule-sdk::result-object.adoc, 1.2@mule-sdk::result-object.adoc
 :keywords: mule, sdk, result, output, mimeType, attributes, operation, source
 
 The `Result` object represents the result of a component's execution. It is used for cases in which the component not only needs to return a value to be set on the message payload but also will specify message attributes and/or a mime type.

--- a/modules/ROOT/pages/return-media-type.adoc
+++ b/modules/ROOT/pages/return-media-type.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::return-media-type.adoc, 1.0@mule-sdk::return-media-type.adoc, 1.2@mule-sdk::return-media-type.adoc
 
 The <<result-object#, `Result` object>> allows you to set the output `mimeType`. However, this setting is optional (SDK developers are not forced to set the `mimeType`).
 

--- a/modules/ROOT/pages/routers.adoc
+++ b/modules/ROOT/pages/routers.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::routers.adoc, 1.0@mule-sdk::routers.adoc, 1.2@mule-sdk::routers.adoc
 :keywords: mule, sdk, routers, router
 
 Conceptually, routers are <<operations#, operations>> that can receive many executable routes and a set of parameters that handle the execution of one, all, or none of them.

--- a/modules/ROOT/pages/scopes.adoc
+++ b/modules/ROOT/pages/scopes.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::scopes.adoc, 1.0@mule-sdk::scopes.adoc, 1.2@mule-sdk::scopes.adoc
 :keywords: mule, sdk, scopes, scope, components
 
 Scopes are similar to <<operations#, Operations>>, but their execution includes the execution of other child <<operations#, Operations>>. This means that a Scope is basically an operation that receives one or more arguments that are simple <<parameters#, Parameters>> along with a single `Chain` component and the `CompletionCallback`.

--- a/modules/ROOT/pages/security-best-practices.adoc
+++ b/modules/ROOT/pages/security-best-practices.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::security-best-practices.adoc, 1.2@mule-sdk::security-best-practices.adoc
 
 The module *must* follow all standard security best practices.
 

--- a/modules/ROOT/pages/security.adoc
+++ b/modules/ROOT/pages/security.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::security.adoc, 1.0@mule-sdk::security.adoc, 1.2@mule-sdk::security.adoc
 :keywords: mule, sdk, security, tls, oauth
 
 The service to which the connector you are creating will connect probably enforces

--- a/modules/ROOT/pages/sources-advanced.adoc
+++ b/modules/ROOT/pages/sources-advanced.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::sources-advanced.adoc, 1.2@mule-sdk::sources-advanced.adoc
 
 == @ClusterSupport
 

--- a/modules/ROOT/pages/sources-async-response.adoc
+++ b/modules/ROOT/pages/sources-async-response.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::sources-async-response.adoc, 1.0@mule-sdk::sources-async-response.adoc, 1.2@mule-sdk::sources-async-response.adoc
 :keywords: mule, sdk, sources, listener, triggers, response, output, asynchronous
 
 Sources can send responses in an asynchronous way. Some of the main uses cases for asynchronous sources are:

--- a/modules/ROOT/pages/sources-config-connection.adoc
+++ b/modules/ROOT/pages/sources-config-connection.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::sources-config-connection.adoc, 1.0@mule-sdk::sources-config-connection.adoc, 1.2@mule-sdk::sources-config-connection.adoc
 :keywords: mule, sdk, sources, listener, triggers, config, connection
 
 == Obtaining the Config Object

--- a/modules/ROOT/pages/sources-lifecycle.adoc
+++ b/modules/ROOT/pages/sources-lifecycle.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::sources-lifecycle.adoc, 1.0@mule-sdk::sources-lifecycle.adoc, 1.2@mule-sdk::sources-lifecycle.adoc
 :keywords: mule, sdk, sources, listener, triggers, lifecycle
 
 Unlike operations, where the lifecycle is tied to the owning Flow, sources can be started or stopped separately through Runtime Manager.

--- a/modules/ROOT/pages/sources-parameters.adoc
+++ b/modules/ROOT/pages/sources-parameters.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::sources-parameters.adoc, 1.0@mule-sdk::sources-parameters.adoc, 1.2@mule-sdk::sources-parameters.adoc
 :keywords: mule, sdk, sources, listener, triggers, parameters
 
 Parameters are defined as fields of your `Source` class. All the features and annotations

--- a/modules/ROOT/pages/sources-push-message.adoc
+++ b/modules/ROOT/pages/sources-push-message.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::sources-push-message.adoc, 1.0@mule-sdk::sources-push-message.adoc, 1.2@mule-sdk::sources-push-message.adoc
 :keywords: mule, sdk, sources, listener, triggers, generate, push, message
 
 After generating a piece of information for the flow, the source uses the `SourceCallback` to send the information to the flow. Returning to the minimalistic HTTP listener example:

--- a/modules/ROOT/pages/sources-response.adoc
+++ b/modules/ROOT/pages/sources-response.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::sources-response.adoc, 1.0@mule-sdk::sources-response.adoc, 1.2@mule-sdk::sources-response.adoc
 :keywords: mule, sdk, sources, listener, triggers, response, output
 
 One of the main properties of a Source indicates whether it generates a response or not.

--- a/modules/ROOT/pages/sources-transactions.adoc
+++ b/modules/ROOT/pages/sources-transactions.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::sources-transactions.adoc, 1.0@mule-sdk::sources-transactions.adoc, 1.2@mule-sdk::sources-transactions.adoc
 :keywords: mule, sdk, sources, listener, triggers, transactions
 
 Just like operations, Message Sources support transactions. Examples of Message Sources include the JMS and VM connector listeners. Both listeners take messages out of a queue and push it to a Flow. If the message processing is successful, the transaction is committed. Otherwise, the transaction is rolled back, and the message goes back to the queue.

--- a/modules/ROOT/pages/sources.adoc
+++ b/modules/ROOT/pages/sources.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::sources.adoc, 1.0@mule-sdk::sources.adoc, 1.2@mule-sdk::sources.adoc
 :keywords: mule, sdk, sources, listener, triggers
 
 Operations are components that process a message and generate a result. Message sources are components that receive or generate new messages to be processed by the Mule Runtime.

--- a/modules/ROOT/pages/special-parameters.adoc
+++ b/modules/ROOT/pages/special-parameters.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::special-parameters.adoc, 1.0@mule-sdk::special-parameters.adoc, 1.2@mule-sdk::special-parameters.adoc
 :keywords: mule, sdk, operation, source, MIME, MIME Type, Encoding, Typed Value, Parameter Resolver, literal
 
 == TypedValue<Type>

--- a/modules/ROOT/pages/static-dynamic-configs.adoc
+++ b/modules/ROOT/pages/static-dynamic-configs.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::static-dynamic-configs.adoc, 1.0@mule-sdk::static-dynamic-configs.adoc, 1.2@mule-sdk::static-dynamic-configs.adoc
 :keywords: mule, sdk, config, dynamic, multitenant, multitenancy
 
 The need to use expressions in a configuration parameter is a common one. Typical use cases are:

--- a/modules/ROOT/pages/static-metadata.adoc
+++ b/modules/ROOT/pages/static-metadata.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::static-metadata.adoc, 1.2@mule-sdk::static-metadata.adoc
 
 *Available since version 1.1*
 

--- a/modules/ROOT/pages/stereotypes.adoc
+++ b/modules/ROOT/pages/stereotypes.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::stereotypes.adoc, 1.0@mule-sdk::stereotypes.adoc, 1.2@mule-sdk::stereotypes.adoc
 :keywords: stereotype, mule, sdk, types
 
 A stereotype is a loose way to classify a component. By assigning a stereotype to a component, you are not implying that it has any specific return type or structure. Instead, you are indicating that it holds something in common with the rest of the components in the same stereotype. You can assign a stereotype to make a parameter belong to the stereotype.

--- a/modules/ROOT/pages/streaming.adoc
+++ b/modules/ROOT/pages/streaming.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::streaming.adoc, 1.0@mule-sdk::streaming.adoc, 1.2@mule-sdk::streaming.adoc
 :keywords: mule, sdk, streaming, data, pagination
 
 In Mule 4, streaming allows automatic and transparent repeatable streams (see About Streaming below for details).

--- a/modules/ROOT/pages/subtypes-mapping.adoc
+++ b/modules/ROOT/pages/subtypes-mapping.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::subtypes-mapping.adoc, 1.0@mule-sdk::subtypes-mapping.adoc, 1.2@mule-sdk::subtypes-mapping.adoc
 :keywords: parameter, parameters, mule, sdk, dsl, xml, subtype, type
 
 Type definitions in the Module API affect the experience provided to the user. The right construction of types can greatly simplify the API that you expose to the user.

--- a/modules/ROOT/pages/testing-writing-your-first-test-case.adoc
+++ b/modules/ROOT/pages/testing-writing-your-first-test-case.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::testing-writing-your-first-test-case.adoc, 1.0@mule-sdk::testing-writing-your-first-test-case.adoc, 1.2@mule-sdk::testing-writing-your-first-test-case.adoc
 
 This section provides a step-by-step introduction to testing a module's
 operation. It explains the basics of test cases that you must perform.

--- a/modules/ROOT/pages/testing.adoc
+++ b/modules/ROOT/pages/testing.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::testing.adoc, 1.0@mule-sdk::testing.adoc, 1.2@mule-sdk::testing.adoc
 
 Testing ensures that a piece of code works correctly. Testing a module is more than simply creating test cases for the business logic. A lot of testing of the interaction
 between the Module and Mule is required to ensure compatibility with the Mule ecosystem.

--- a/modules/ROOT/pages/threading-asynchronous-processing.adoc
+++ b/modules/ROOT/pages/threading-asynchronous-processing.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::threading-asynchronous-processing.adoc, 1.2@mule-sdk::threading-asynchronous-processing.adoc
 
 Most modules *should not* have concurrency concerns other than designing for Thread safety.
 

--- a/modules/ROOT/pages/tls.adoc
+++ b/modules/ROOT/pages/tls.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::tls.adoc, 1.0@mule-sdk::tls.adoc, 1.2@mule-sdk::tls.adoc
 :keywords: mule, sdk, security, tls
 
 Adding support for TLS configuration in your module is as simple as declaring a <<parameters#, parameter>> of type `TlsContextFactory`, for example:

--- a/modules/ROOT/pages/transactions.adoc
+++ b/modules/ROOT/pages/transactions.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::transactions.adoc, 1.0@mule-sdk::transactions.adoc, 1.2@mule-sdk::transactions.adoc
 :keywords: mule, sdk, operation, source, tx, transactions, xa
 
 The SDK supports the creation of connectors that join and create a new transaction in a Mule Flow, including Source and Operation executions that work as a unit. So, if a problem occurs inside the flow, all the components participating in the transaction will roll back their execution as a unit. All operations within the transaction are rolled back so that no one part results in partial completion.

--- a/modules/ROOT/pages/validators.adoc
+++ b/modules/ROOT/pages/validators.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::validators.adoc, 1.0@mule-sdk::validators.adoc, 1.2@mule-sdk::validators.adoc
 :keywords: validation, validators, mule, sdk
 
 Validators are operations validate the Mule Message without changing the message. Validators can produce these effects:

--- a/modules/ROOT/pages/value-providers.adoc
+++ b/modules/ROOT/pages/value-providers.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::value-providers.adoc, 1.0@mule-sdk::value-providers.adoc, 1.2@mule-sdk::value-providers.adoc
 :keywords: mule, sdk, value provider, dynamic values
 
 When developing a connector, you can let the end user select a parameter

--- a/modules/ROOT/pages/xml-sdk.adoc
+++ b/modules/ROOT/pages/xml-sdk.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: 1.1@mule-sdk::xml-sdk.adoc, 1.2@mule-sdk::xml-sdk.adoc
 :keywords:
 :toc:
 


### PR DESCRIPTION
This PR addresses the following changes:

- Makes v1.1 the default latest branch. 
- Creates the necessary page-aliases to redirect from versions 1.0 1.1 and 1.2.

I tested these redirects against all existing paths for versioned documentation and all URLs still return a valid page.
mule-sdk/1.0/.* -> mule-sdk/.*
mule-sdk/1.1/.* -> mule-sdk/.*
mule-sdk/1.2/.* -> mule-sdk/.*