### PR TITLE
Correct role attribute value for parameter

### DIFF
--- a/modules/ROOT/pages/xml-sdk.adoc
+++ b/modules/ROOT/pages/xml-sdk.adoc
@@ -127,10 +127,10 @@ To use an XML SDK module in a Mule app, you simply add it to a Mule flow, for ex
 
 | `role`
 | required
-| `behavior`
+| `BEHAVIOUR`
 | Set of defined roles for a given parameter that modifies the generated XSD for the current `<parameter>`.
 
-* `behavior` renders an attribute.
+* `BEHAVIOUR` renders an attribute.
 * `CONTENT` implies support for DataWeave in place as a child element.
 * `PRIMARY` works like `CONTENT` but maps to the payload by default.
 


### PR DESCRIPTION
The list of possible values for attribute "role" contained the value "behavior", while it accepts "BEHAVIOUR" instead.

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released