### PR TITLE
W-21553100: Update MuleSoft Help Center links to Salesforce Help

### DIFF
--- a/modules/ROOT/pages/HTTP-based-connectors.adoc
+++ b/modules/ROOT/pages/HTTP-based-connectors.adoc
@@ -253,5 +253,5 @@ The connector *must* support the HTTPS scheme whenever possible and *must* consi
 
 == See Also
 
-* https://help.mulesoft.com[MuleSoft Help Center]
+* https://help.salesforce.com[Salesforce Help]
 * xref:mule-sdk::best-practices.adoc[Mule SDK Development Best Practices]

--- a/modules/ROOT/pages/best-practices.adoc
+++ b/modules/ROOT/pages/best-practices.adoc
@@ -45,4 +45,4 @@ The same applies to a custom Mule module or connector, which needs to be approac
 
 == See Also
 
-* https://help.mulesoft.com[MuleSoft Help Center]
+* https://help.salesforce.com[Salesforce Help]

--- a/modules/ROOT/pages/define-configurations-and-connection-providers.adoc
+++ b/modules/ROOT/pages/define-configurations-and-connection-providers.adoc
@@ -206,5 +206,5 @@ Configuration, ConnectionProvider and Connection classes *must not* be exported 
 
 == See Also
 
-* https://help.mulesoft.com[MuleSoft Help Center]
+* https://help.salesforce.com[Salesforce Help]
 * xref:mule-sdk::best-practices.adoc[Mule SDK Development Best Practices]

--- a/modules/ROOT/pages/define-operations.adoc
+++ b/modules/ROOT/pages/define-operations.adoc
@@ -273,5 +273,5 @@ When an operation interacts with a transactional system (including XA transactio
 
 == See Also
 
-* https://help.mulesoft.com[MuleSoft Help Center]
+* https://help.salesforce.com[Salesforce Help]
 * xref:mule-sdk::best-practices.adoc[Mule SDK Development Best Practices]

--- a/modules/ROOT/pages/define-parameters.adoc
+++ b/modules/ROOT/pages/define-parameters.adoc
@@ -578,5 +578,5 @@ You cannot add parameters or POJOs with types `org.mule.runtime.core.api.source.
 
 == See Also
 
-* https://help.mulesoft.com[MuleSoft Help Center]
+* https://help.salesforce.com[Salesforce Help]
 * xref:mule-sdk::best-practices.adoc[Mule SDK Development Best Practices]

--- a/modules/ROOT/pages/define-sources.adoc
+++ b/modules/ROOT/pages/define-sources.adoc
@@ -114,5 +114,5 @@ These can be controlled using the @Alias annotation.
 
 == See Also
 
-* https://help.mulesoft.com[MuleSoft Help Center]
+* https://help.salesforce.com[Salesforce Help]
 * xref:mule-sdk::best-practices.adoc[Mule SDK Development Best Practices]

--- a/modules/ROOT/pages/error-handling.adoc
+++ b/modules/ROOT/pages/error-handling.adoc
@@ -91,5 +91,5 @@ Exception, ErrorTypeDefinition, and ErrorTypeProvider classes defined in the mod
 
 == See Also
 
-* https://help.mulesoft.com[MuleSoft Help Center]
+* https://help.salesforce.com[Salesforce Help]
 * xref:mule-sdk::best-practices.adoc[Mule SDK Development Best Practices]

--- a/modules/ROOT/pages/general-coding-rules.adoc
+++ b/modules/ROOT/pages/general-coding-rules.adoc
@@ -338,5 +338,5 @@ For more information, refer to xref:java-version-support.adoc[].
 
 == See Also
 
-* https://help.mulesoft.com[MuleSoft Help Center]
+* https://help.salesforce.com[Salesforce Help]
 * xref:mule-sdk::best-practices.adoc[Mule SDK Development Best Practices]

--- a/modules/ROOT/pages/security-best-practices.adoc
+++ b/modules/ROOT/pages/security-best-practices.adoc
@@ -15,5 +15,5 @@ In particular, the following *should* be given special consideration:
 
 == See Also
 
-* https://help.mulesoft.com[MuleSoft Help Center]
+* https://help.salesforce.com[Salesforce Help]
 * xref:mule-sdk::best-practices.adoc[Mule SDK Development Best Practices]

--- a/modules/ROOT/pages/threading-asynchronous-processing.adoc
+++ b/modules/ROOT/pages/threading-asynchronous-processing.adoc
@@ -140,5 +140,5 @@ public class ExampleSourceScheduler extends Source<Serializable, VMMessageAttrib
 
 == See Also
 
-* https://help.mulesoft.com[MuleSoft Help Center]
+* https://help.salesforce.com[Salesforce Help]
 * xref:mule-sdk::best-practices.adoc[Mule SDK Development Best Practices]

--- a/modules/ROOT/pages/troubleshooting.adoc
+++ b/modules/ROOT/pages/troubleshooting.adoc
@@ -197,5 +197,5 @@ To fix this error, either:
 
 == See Also
 
-* https://help.mulesoft.com[MuleSoft Help Center]
+* https://help.salesforce.com[Salesforce Help]
 include::release-notes::partial$release-notes/rn-known-issues.adoc[tag=knownIssuesSeeAlsoLink]


### PR DESCRIPTION
Updates all "https://help.mulesoft.com[MuleSoft Help Center]" references to "https://help.salesforce.com[Salesforce Help]" and removes the ^ from link text.